### PR TITLE
Rename machine names for Container and Width

### DIFF
--- a/config/field.storage.paragraph.sa_container.yml
+++ b/config/field.storage.paragraph.sa_container.yml
@@ -4,24 +4,18 @@ dependencies:
   module:
     - options
     - paragraphs
-id: paragraph.sa_col
-field_name: sa_col
+id: paragraph.sa_container
+field_name: sa_container
 entity_type: paragraph
 type: list_string
 settings:
   allowed_values:
     -
-      value: 'col-lg-9 col-12'
-      label: 75%
+      value: container
+      label: Standard
     -
-      value: 'col-lg-6 col-12'
-      label: 50%
-    -
-      value: 'col-lg-3 col-12'
-      label: 25%
-    -
-      value: 'col-lg-4 col-12'
-      label: 33%
+      value: container-fluid
+      label: 'Full Width'
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/field.storage.paragraph.sa_width.yml
+++ b/config/field.storage.paragraph.sa_width.yml
@@ -11,11 +11,17 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: container
-      label: Standard
+      value: 'col-lg-9 col-12'
+      label: 75%
     -
-      value: container-fluid
-      label: 'Full Width'
+      value: 'col-lg-6 col-12'
+      label: 50%
+    -
+      value: 'col-lg-3 col-12'
+      label: 25%
+    -
+      value: 'col-lg-4 col-12'
+      label: 33%
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Rename machine names for Container and Width](https://kanopi.teamwork.com/app/tasks/29484155)

> Currently the machine name for Container is sa_width and the machine name for Width is sa_col.

Please update the field storage name for Container to be sa_container and the Width Field to be sa_width.

All field names and configs will need to be updated with the changes. Templates in saplings_child will also need to be updated as well.


## Acceptance Criteria
* Machine names have been updated for container and width
* Config files have been renamed
